### PR TITLE
Issue #7: Checking for python support

### DIFF
--- a/doc/jakeSender.txt
+++ b/doc/jakeSender.txt
@@ -179,6 +179,7 @@ The following key mappings are provided by default:
     - Added SendSelectionToMaya and SendSelectionToMobu to fix issue with
       sending trying to send the full buffer and instead sending the previous
       visual selection.
+    - Checking for python support upon loading the plugin
 
 ==============================================================================
 10. License                                                *JakeSenderLicense*

--- a/plugin/jakeSender.vim
+++ b/plugin/jakeSender.vim
@@ -73,7 +73,7 @@ vnoremap <leader>sx :<C-U>SendSelectionToMobu<cr>
 
 " Let's check that we have python support (for people that didn't RTFM)
 if !has ('python')
-    echoerr "vim-JakeSender requires Vim compiled with Python support."
+    echoerr 'vim-JakeSender requires Vim compiled with Python support.'
     finish
 endif
 "

--- a/plugin/jakeSender.vim
+++ b/plugin/jakeSender.vim
@@ -71,6 +71,12 @@ vnoremap <leader>sm :<C-U>SendSelectionToMaya<cr>
 nnoremap <leader>sx :SendSelectionToMobu<cr>
 vnoremap <leader>sx :<C-U>SendSelectionToMobu<cr>
 
+" Let's check that we have python support (for people that didn't RTFM)
+if !has ('python')
+    echoerr "vim-JakeSender requires Vim compiled with Python support."
+    finish
+endif
+"
 " Python code (This is where the magic is)
 
 python << EOF


### PR DESCRIPTION
Vim plugin will now check for python support and display a nice error if Vim was not compiled with it.